### PR TITLE
Gemfile: downgrade rack to not require ruby > 2.2.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,7 @@ source "https://rubygems.org"
 gem "rspec"
 gem "capybara"
 gem "poltergeist"
+
+# make sure rack doesn't require ruby >= 2.2.2
+# as we have ruby 2.1 on SLE12
+gem "rack", "~> 1.6.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     addressable (2.5.0)
       public_suffix (~> 2.0, >= 2.0.2)
-    capybara (2.12.0)
+    capybara (2.12.1)
       addressable
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -23,7 +23,7 @@ GEM
       cliver (~> 0.3.1)
       websocket-driver (>= 0.2.0)
     public_suffix (2.0.5)
-    rack (2.0.1)
+    rack (1.6.5)
     rack-test (0.6.3)
       rack (>= 1.0)
     rspec (3.5.0)
@@ -51,6 +51,7 @@ PLATFORMS
 DEPENDENCIES
   capybara
   poltergeist
+  rack (~> 1.6.5)
   rspec
 
 BUNDLED WITH


### PR DESCRIPTION
otherwise we can't run this tests on any SLE12 machine

Signed-off-by: Maximilian Meister <mmeister@suse.de>