### PR TITLE
concourse: provide a minimal api to interact with the e2e tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,5 @@ gem "poltergeist"
 # make sure rack doesn't require ruby >= 2.2.2
 # as we have ruby 2.1 on SLE12
 gem "rack", "~> 1.6.5"
+gem "sinatra"
+gem "sinatra-contrib"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ GEM
   specs:
     addressable (2.5.0)
       public_suffix (~> 2.0, >= 2.0.2)
+    backports (3.6.8)
     capybara (2.12.1)
       addressable
       mime-types (>= 1.16)
@@ -16,6 +17,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
+    multi_json (1.12.1)
     nokogiri (1.7.0.1)
       mini_portile2 (~> 2.1.0)
     poltergeist (1.13.0)
@@ -24,6 +26,8 @@ GEM
       websocket-driver (>= 0.2.0)
     public_suffix (2.0.5)
     rack (1.6.5)
+    rack-protection (1.5.3)
+      rack
     rack-test (0.6.3)
       rack (>= 1.0)
     rspec (3.5.0)
@@ -39,6 +43,18 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
+    sinatra (1.4.8)
+      rack (~> 1.5)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
+    sinatra-contrib (1.4.7)
+      backports (>= 2.0)
+      multi_json
+      rack-protection
+      rack-test
+      sinatra (~> 1.4.0)
+      tilt (>= 1.3, < 3)
+    tilt (2.0.6)
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -53,6 +69,8 @@ DEPENDENCIES
   poltergeist
   rack (~> 1.6.5)
   rspec
+  sinatra
+  sinatra-contrib
 
 BUNDLED WITH
    1.13.7

--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,8 @@
+### small api to trigger the e2e test and to fetch the result
+
+This is used by the CI to determine if a test was successful or not, and to query if a test is currently running
+
+run with:
+```
+$ ruby api.rb
+```

--- a/api/api.rb
+++ b/api/api.rb
@@ -1,0 +1,50 @@
+require "sinatra/base"
+require "sinatra/json"
+
+require "json"
+require "pathname"
+
+class RspecResultApi < Sinatra::Base
+  set :root, File.expand_path("../..", __FILE__)
+  set :bind, "0.0.0.0"
+
+  helpers do
+    def result_file_path
+      Pathname.new(settings.root).join("e2e-result.json")
+    end
+
+    def json_result
+      JSON.parse(result_file_path.read)
+    end
+
+    def run!
+      Thread.new do
+        Dir.chdir(settings.root) do
+          `bundle exec rspec --format json -o e2e-result.json spec/**/* >/dev/null 2>&1`
+        end
+      end
+    end
+  end
+
+  post '/start' do
+    # if the json file doesn't exist initially
+    run! && return unless result_file_path.exist?
+    # return temporary unavailable if test is already running
+    result_file_path.size.zero? ? (status 503) : run!
+  end
+
+  get '/result' do
+    json(
+      (json_result rescue {}) # when file is empty
+    )
+  end
+
+  get '/status' do
+    json(
+      running: (result_file_path.size.zero? rescue false), # when file doesn't exist initially
+      success: (json_result["summary"]["failure_count"].zero? rescue false) # when file is empty
+    )
+  end
+
+  run! if app_file == $0
+end


### PR DESCRIPTION
* trigger a build
* fetch the result
* determine if test is running

## Depends on https://github.com/kubic-project/e2e-tests/pull/3

NOTE: this will probably be run on one of our workers and serve as an interface for the ci job