### PR TITLE
fix ./stop_kubelet: No such file or directory

### DIFF
--- a/scripts/cleanup_environment
+++ b/scripts/cleanup_environment
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 
-SCRIPT_DIR="$(dirname $0)"
+pushd `dirname $0` > /dev/null
+SCRIPT_DIR=`pwd -P`
+popd > /dev/null
+
 source $SCRIPT_DIR/common
 
 cd $VELUM_DIR/kubernetes


### PR DESCRIPTION
SCRIPT_DIR evaluates to "." therefore the next cd is wrong

Signed-off-by: Maximilian Meister <mmeister@suse.de>