### PR TITLE
cleanup manifests

### DIFF
--- a/scripts/cleanup_environment
+++ b/scripts/cleanup_environment
@@ -8,6 +8,10 @@ source $SCRIPT_DIR/common
 
 cd $VELUM_DIR/kubernetes
 ./cleanup
+# if there is a change in the templates (e.g. filename) this will leave
+# the old manifests in place which leads to spawning unwanted pods
+# so clean them up
+rm -rf manifests/*
 cd $SCRIPT_DIR
 ./stop_kubelet
 


### PR DESCRIPTION
if there is a change in the templates (e.g. filename) this will leave
the old manifests in place which leads to spawning unwanted pods

clean them up to prevent this behavior

Signed-off-by: Maximilian Meister <mmeister@suse.de>