### PR TITLE
reduce logging

### DIFF
--- a/scripts/cleanup_minions
+++ b/scripts/cleanup_minions
@@ -44,7 +44,7 @@ do
 done
 
 # remove network bridges if they have not been cleaned up for some reason (aka terraform)
-for bridge in $(virsh net-info e2e_testsnet | grep Bridge | awk '{print $2}'); do
+for bridge in $(virsh net-info e2e_testsnet 2>/dev/null | grep Bridge | awk '{print $2}'); do
   sudo ifconfig down $bridge || :
   sudo brctl delbr $bridge || :
 done


### PR DESCRIPTION
hide stderr as it will not find a network in most of the cases
otherwise this gives the impression that the tests failed

Signed-off-by: Maximilian Meister <mmeister@suse.de>

related: https://github.com/kubic-project/velum/pull/94#issuecomment-293573175