### PR TITLE
Revert "register before logging in"

### DIFF
--- a/spec/features/boostrap_cluster.rb
+++ b/spec/features/boostrap_cluster.rb
@@ -8,7 +8,6 @@ feature "Boostrap cluster" do
 
     puts "Starting environment"
     start_environment
-    register
     login
     puts "Spawning minions"
     spawn_minions 2

--- a/spec/support/container.rb
+++ b/spec/support/container.rb
@@ -28,6 +28,7 @@ class Container
 
   def command(command, verbose: false)
     cmd_string = "docker exec #{container_id} #{command}"
+    puts ">>> #{cmd_string}"
     self.class.system_command(command: cmd_string, verbose: verbose)
   end
 end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -105,14 +105,6 @@ module Helpers
     fill_in "user_password", with: "password"
     click_on "Log in"
   end
-
-  def register
-    visit "/users/sign_up"
-    fill_in "user_email", with: "test@test.com"
-    fill_in "user_password", with: "password"
-    fill_in "user_password_confirmation", with: "password"
-    click_on "Create Admin"
-  end
 end
 
 RSpec.configure { |config| config.include Helpers, type: :feature }


### PR DESCRIPTION
apparently the test user is still present, and after creating an
account we are immediately logged in, so the next login step is
failing

This reverts commit eff572f8c67504f3a0b6688fb429b6926e294ad6.