### PR TITLE
lower the timeout

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -61,6 +61,6 @@ RSpec.configure do |config|
 
   # Set a timeout around the tests
   config.around(:each) do |test|
-    Timeout::timeout(1800) { test.run }
+    Timeout::timeout(460) { test.run }
   end
 end


### PR DESCRIPTION
an average tests takes ~ 360s

Signed-off-by: Maximilian Meister <mmeister@suse.de>