### PR TITLE
Update e2e tests

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -61,9 +61,11 @@ RSpec.configure do |config|
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
   # Set a timeout around the tests
+  timeout = ENV.fetch('TEST_TIMEOUT', 460).to_i
+
   config.around(:each) do |test|
     begin
-      Timeout.timeout(460) { test.run }
+      Timeout::timeout(timeout) { test.run }
     rescue Timeout::Error
       fail
     end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -116,7 +116,9 @@ module Helpers
 
   def configure
     visit "/setup"
-    fill_in "settings_dashboard", with: `hostname -f`.strip
+    dashboard = system_command(command: "ip addr show $(awk '$2 == 00000000 { print $1 }' /proc/net/route) | awk '$1 == \"inet\" {print $2}' | cut -f1 -d/")[:stdout]
+    fill_in "settings_dashboard", with: dashboard
+    fill_in 'settings_apiserver', with: "localhost"
     fill_in "settings_company_name", with: "SUSE LLC"
     fill_in "settings_company_unit", with: "QA"
     fill_in "settings_email", with: "containers@suse.de"


### PR DESCRIPTION
This allows the tests to pass again.

Also allows for overriding the timeout, as on a slow connection, it can take longer