### PR TITLE
e2e-ci got serialized

### DIFF
--- a/api/api.rb
+++ b/api/api.rb
@@ -46,10 +46,7 @@ class RspecResultApi < Sinatra::Base
     env_vars["TERRAFORM_BRANCH"] = params["terraform-branch"]
     env_vars["CONTAINER_MANIFESTS_BRANCH"] = params["container-manifests-branch"]
 
-    # if the json file doesn't exist initially
-    run!(env_vars) && return unless result_file_path.exist?
-    # return temporary unavailable if test is already running
-    result_file_path.size.zero? ? (status 503) : run!(env_vars)
+    run!(env_vars)
   end
 
   get '/result' do


### PR DESCRIPTION
we are now enforcing to run only one test at a time from the ci side

so we can just always trigger tests upon request of that route

Signed-off-by: Maximilian Meister <mmeister@suse.de>