### PR TITLE
Remove sudo -v call

### DIFF
--- a/scripts/cleanup_minions
+++ b/scripts/cleanup_minions
@@ -8,9 +8,6 @@ if [ -d "$TERRAFORM_DIR" ]; then
   FORCE=true timeout 3m contrib/libvirt/k8s-libvirt.sh destroy
 fi
 
-# Manual cleanup (because sometimes the above leaves garbage behind)
-sudo -v # Get sudo access
-
 # Remove domains
 sudo virsh list --all | tail -n +3 | grep e2e_tests | awk '{print $2}' | while read domain
 do


### PR DESCRIPTION
This does nothing the first sudo call wouldn't have done, and forces
a password prompt when one wouldn't otherwise be necessary.