### PR TITLE
Increase wait timeout while waiting for minions to be registered

### DIFF
--- a/spec/features/bootstrap_cluster.rb
+++ b/spec/features/bootstrap_cluster.rb
@@ -39,7 +39,7 @@ feature "Boostrap cluster" do
     find("#accept-all").click
     # Wait until Minions are registered
     command = "entrypoint.sh rails runner 'ActiveRecord::Base.logger=nil; puts Minion.count'"
-    minions_registered = loop_with_timeout(timeout: 35, interval: 1) do
+    minions_registered = loop_with_timeout(timeout: 120, interval: 1) do
       dashboard_container.command(command)[:stdout].to_i == 2
     end
     expect(minions_registered).to be(true)


### PR DESCRIPTION
We depend on the event processor, so wait a little more.