### PR TITLE
Always dump container logs

### DIFF
--- a/spec/features/bootstrap_cluster.rb
+++ b/spec/features/bootstrap_cluster.rb
@@ -20,7 +20,7 @@ feature "Boostrap cluster" do
   end
 
   after do |example|
-    dump_container_logs if example.exception
+    dump_container_logs
     unless ENV["KEEP"]
       cleanup_environment
       cleanup_minions


### PR DESCRIPTION
By always dumping containers logs we make sure the `containers.log` we
are inspecting is the one from the last run, since even after a success
it might be interesting to inspect the output of the containers for
different reasons.